### PR TITLE
Add sendAll hook for the anchor provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "react-async-hook": "^3.6.2",
     "@project-serum/serum": "^0.13.34",
-    "@project-serum/swap": "^0.1.0-alpha.11",
+    "@project-serum/swap": "^0.1.0-alpha.12",
     "@solana/spl-token": "^0.1.4"
   },
   "peerDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -154,6 +154,22 @@ class NotifyingProvider extends Provider {
       return "";
     }
   }
+
+  async sendAll(
+    txs: Array<{ tx: Transaction; signers: Array<Account | undefined> }>,
+    opts?: ConfirmOptions
+  ): Promise<Array<TransactionSignature>> {
+    try {
+      const txSigs = await super.sendAll(txs, opts);
+      txSigs.forEach((sig) => {
+        this.onTransaction(sig);
+      });
+      return txSigs;
+    } catch (err) {
+      this.onTransaction(undefined, err);
+      return [];
+    }
+  }
 }
 
 export default App;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1588,10 +1588,10 @@
     bs58 "^4.0.1"
     eventemitter3 "^4.0.4"
 
-"@project-serum/swap@^0.1.0-alpha.11":
-  version "0.1.0-alpha.11"
-  resolved "https://registry.yarnpkg.com/@project-serum/swap/-/swap-0.1.0-alpha.11.tgz#65c6393bdc511208453c853095eba32e0748191b"
-  integrity sha512-cxjxweWrZWcxfazkxSjDXqLquKlCCOoJ7z+cfAky/l29gRet+rLbGjyd+TAcZRDrIfh+kut9svPlL/bXK9vIOw==
+"@project-serum/swap@^0.1.0-alpha.12":
+  version "0.1.0-alpha.12"
+  resolved "https://registry.yarnpkg.com/@project-serum/swap/-/swap-0.1.0-alpha.12.tgz#085055c1bbed66d8e9a9f8da9e23d2315ad09181"
+  integrity sha512-iIFBbwkIVAJaUPx3Wn240gba6tpAtBHHfcEbInz+O+enCUUHCCIi96SY1R6nBHKNWiH2qY+nlPfXR62Lra/cyw==
   dependencies:
     "@project-serum/anchor" "^0.5.1-beta.2"
     "@project-serum/serum" "^0.13.34"


### PR DESCRIPTION
The latest updates to `@project-serum/swap` break up instructions into multiple transactions in the event the transaction would be over the transaction size limit. As a result, it must use `Provider.sendAll`. The changes here override the method so that the example app can show notifications when the method is invoked. 