### PR TITLE
Cache promises

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-serum/swap-ui",
-  "version": "0.1.0-alpha.10",
+  "version": "0.1.0-alpha.11",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "homepage": ".",

--- a/src/swap/context/Token.tsx
+++ b/src/swap/context/Token.tsx
@@ -130,7 +130,7 @@ export function useMint(mint?: PublicKey): MintInfo | undefined | null {
       TOKEN_PROGRAM_ID,
       new Account()
     );
-    const mintInfo = await mintClient.getMintInfo();
+    const mintInfo =  mintClient.getMintInfo();
     _MINT_CACHE.set(mint.toString(), mintInfo);
     return mintInfo;
   }, [provider.connection, mint]);
@@ -148,4 +148,4 @@ const _OWNED_TOKEN_ACCOUNTS_CACHE: Array<{
 }> = [];
 
 // Cache storing all previously fetched mint infos.
-const _MINT_CACHE = new Map<string, MintInfo>();
+const _MINT_CACHE = new Map<string, Promise<MintInfo>>();

--- a/src/swap/context/Token.tsx
+++ b/src/swap/context/Token.tsx
@@ -130,7 +130,7 @@ export function useMint(mint?: PublicKey): MintInfo | undefined | null {
       TOKEN_PROGRAM_ID,
       new Account()
     );
-    const mintInfo =  mintClient.getMintInfo();
+    const mintInfo = mintClient.getMintInfo();
     _MINT_CACHE.set(mint.toString(), mintInfo);
     return mintInfo;
   }, [provider.connection, mint]);


### PR DESCRIPTION
* For all caches, uses a Promise in the value instead of the direct object. This also prevents redundant network requests, since if multiple components are fetching the same item in parallel, the second one will see the (potentially unresolved) promise in the cache, and therefore not refetch.
* Uses a global cache for storing serum `Market` clients to prevent unnecessary network requests.