### PR TITLE
Fix max button wrapping

### DIFF
--- a/src/components/Swap.tsx
+++ b/src/components/Swap.tsx
@@ -70,6 +70,7 @@ const useStyles = makeStyles((theme) => ({
     marginLeft: "5px",
     display: "flex",
     flexDirection: "column",
+    width: "50%",
   },
   balanceContainer: {
     display: "flex",


### PR DESCRIPTION
The max button currently wraps around when the balance is too large.