### PR TITLE
Pass through wallet to swap api

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-serum/swap-ui",
-  "version": "0.1.0-alpha.18",
+  "version": "0.1.0-alpha.19",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "homepage": "https://github.com/project-serum/swap-ui",
@@ -15,7 +15,7 @@
     "@material-ui/core": "^4.11.4",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
-    "@project-serum/anchor": "^0.6.0-beta.1",
+    "@project-serum/anchor": "^0.7.0",
     "@solana/spl-token-registry": "^0.2.86",
     "@solana/web3.js": "^1.10.1",
     "material-ui-popup-state": "^1.8.3",

--- a/src/components/Swap.tsx
+++ b/src/components/Swap.tsx
@@ -319,6 +319,8 @@ function SwapButton() {
   const canSwap = useCanSwap();
   const referral = useReferral(fromMarket);
   const fair = useSwapFair();
+  const fromWallet = useOwnedTokenAccount(fromMint);
+  const toWallet = useOwnedTokenAccount(toMint);
 
   // Click handler.
   const sendSwapTransaction = async () => {
@@ -347,6 +349,8 @@ function SwapButton() {
     await swapClient.swap({
       fromMint,
       toMint,
+      fromWallet: fromWallet ? fromWallet.publicKey : undefined,
+      toWallet: toWallet ? toWallet.publicKey : undefined,
       amount,
       minExchangeRate,
       referral,


### PR DESCRIPTION
These changes allow one to use auxilliary token accounts to swap. Previously we only allowed associated token accounts.