### PR TITLE
Mobile friendly swap widget using Material UI's 'theme.spacing()'

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from "react";
 import { SnackbarProvider, useSnackbar } from "notistack";
-import { Button } from "@material-ui/core";
+import { Button, Grid, makeStyles } from "@material-ui/core";
 import { Provider } from "@project-serum/anchor";
 // @ts-ignore
 import Wallet from "@project-serum/sol-wallet-adapter";
@@ -30,7 +30,16 @@ function App() {
   );
 }
 
+const useStyles = makeStyles((theme) => ({
+  root: {
+    minHeight: "100vh",
+    paddingLeft: theme.spacing(1),
+    paddingRight: theme.spacing(1),
+  },
+}));
+
 function AppInner() {
+  const styles = useStyles();
   const { enqueueSnackbar } = useSnackbar();
   const [isConnected, setIsConnected] = useState(false);
   const [tokenList, setTokenList] = useState<TokenListContainer | null>(null);
@@ -90,20 +99,11 @@ function AppInner() {
   }, [wallet, enqueueSnackbar]);
 
   return (
-    <div
-      style={{
-        width: "450px",
-        marginLeft: "auto",
-        marginRight: "auto",
-        position: "absolute",
-        left: 0,
-        right: 0,
-        top: 0,
-        bottom: 0,
-        display: "flex",
-        justifyContent: "center",
-        flexDirection: "column",
-      }}
+    <Grid
+      container
+      justify="center"
+      alignItems="center"
+      className={styles.root}
     >
       <Button
         variant="outlined"
@@ -113,7 +113,7 @@ function AppInner() {
         {!isConnected ? "Connect" : "Disconnect"}
       </Button>
       {tokenList && <Swap provider={provider} tokenList={tokenList} />}
-    </div>
+    </Grid>
   );
 }
 

--- a/src/components/Swap.tsx
+++ b/src/components/Swap.tsx
@@ -27,7 +27,7 @@ import { InfoLabel } from "./Info";
 
 const useStyles = makeStyles((theme) => ({
   card: {
-    width: theme.spacing(56),
+    width: theme.spacing(50),
     borderRadius: theme.spacing(2),
     boxShadow: "0px 0px 30px 5px rgba(0,0,0,0.075)",
     padding: theme.spacing(2),
@@ -40,12 +40,12 @@ const useStyles = makeStyles((theme) => ({
   },
   swapButton: {
     width: "100%",
-    borderRadius: theme.spacing(1.4),
+    borderRadius: theme.spacing(2),
     backgroundColor: theme.palette.primary.main,
     color: theme.palette.primary.contrastText,
     fontSize: 16,
     fontWeight: 700,
-    padding: theme.spacing(1.2),
+    padding: theme.spacing(1.5),
   },
   swapToFromButton: {
     display: "block",
@@ -60,7 +60,7 @@ const useStyles = makeStyles((theme) => ({
     textAlign: "right",
   },
   swapTokenFormContainer: {
-    borderRadius: theme.spacing(1.5),
+    borderRadius: theme.spacing(2),
     boxShadow: "0px 0px 15px 2px rgba(33,150,243,0.1)",
     display: "flex",
     justifyContent: "space-between",
@@ -117,13 +117,12 @@ export default function SwapCard({
 }
 
 export function SwapHeader() {
-  const theme = useTheme();
   return (
     <div
       style={{
         display: "flex",
         justifyContent: "space-between",
-        marginBottom: theme.spacing(2.6),
+        marginBottom: "16px",
       }}
     >
       <Typography
@@ -266,7 +265,7 @@ function TokenButton({
 
   return (
     <div onClick={onClick} className={styles.tokenButton}>
-      <TokenIcon mint={mint} style={{ width: theme.spacing(3.6) }} />
+      <TokenIcon mint={mint} style={{ width: theme.spacing(4) }} />
       <TokenName mint={mint} style={{ fontSize: 14, fontWeight: 700 }} />
       <ExpandMore />
     </div>
@@ -301,7 +300,7 @@ function TokenName({ mint, style }: { mint: PublicKey; style: any }) {
   return (
     <Typography
       style={{
-        marginLeft: theme.spacing(1.4),
+        marginLeft: theme.spacing(2),
         marginRight: theme.spacing(1),
         ...style,
       }}

--- a/src/components/Swap.tsx
+++ b/src/components/Swap.tsx
@@ -27,10 +27,10 @@ import { InfoLabel } from "./Info";
 
 const useStyles = makeStyles((theme) => ({
   card: {
-    width: "450px",
-    borderRadius: "16px",
+    width: theme.spacing(56),
+    borderRadius: theme.spacing(2),
     boxShadow: "0px 0px 30px 5px rgba(0,0,0,0.075)",
-    padding: "16px",
+    padding: theme.spacing(2),
   },
   tab: {
     width: "50%",
@@ -40,12 +40,12 @@ const useStyles = makeStyles((theme) => ({
   },
   swapButton: {
     width: "100%",
-    borderRadius: "10px",
+    borderRadius: theme.spacing(1.4),
     backgroundColor: theme.palette.primary.main,
     color: theme.palette.primary.contrastText,
     fontSize: 16,
     fontWeight: 700,
-    padding: "10px",
+    padding: theme.spacing(1.2),
   },
   swapToFromButton: {
     display: "block",
@@ -60,14 +60,14 @@ const useStyles = makeStyles((theme) => ({
     textAlign: "right",
   },
   swapTokenFormContainer: {
-    borderRadius: "10px",
+    borderRadius: theme.spacing(1.5),
     boxShadow: "0px 0px 15px 2px rgba(33,150,243,0.1)",
     display: "flex",
     justifyContent: "space-between",
-    padding: "10px",
+    padding: theme.spacing(1),
   },
   swapTokenSelectorContainer: {
-    marginLeft: "5px",
+    marginLeft: theme.spacing(1),
     display: "flex",
     flexDirection: "column",
     width: "50%",
@@ -78,7 +78,7 @@ const useStyles = makeStyles((theme) => ({
     fontSize: "14px",
   },
   maxButton: {
-    marginLeft: 10,
+    marginLeft: theme.spacing(1),
     color: theme.palette.primary.main,
     fontWeight: 700,
     fontSize: "12px",
@@ -88,7 +88,7 @@ const useStyles = makeStyles((theme) => ({
     display: "flex",
     alignItems: "center",
     cursor: "pointer",
-    marginBottom: "10px",
+    marginBottom: theme.spacing(1),
   },
 }));
 
@@ -117,12 +117,13 @@ export default function SwapCard({
 }
 
 export function SwapHeader() {
+  const theme = useTheme();
   return (
     <div
       style={{
         display: "flex",
         justifyContent: "space-between",
-        marginBottom: "20px",
+        marginBottom: theme.spacing(2.6),
       }}
     >
       <Typography
@@ -261,10 +262,11 @@ function TokenButton({
   onClick: () => void;
 }) {
   const styles = useStyles();
+  const theme = useTheme();
 
   return (
     <div onClick={onClick} className={styles.tokenButton}>
-      <TokenIcon mint={mint} style={{ width: "30px" }} />
+      <TokenIcon mint={mint} style={{ width: theme.spacing(3.6) }} />
       <TokenName mint={mint} style={{ fontSize: 14, fontWeight: 700 }} />
       <ExpandMore />
     </div>
@@ -293,9 +295,17 @@ export function TokenIcon({ mint, style }: { mint: PublicKey; style: any }) {
 
 function TokenName({ mint, style }: { mint: PublicKey; style: any }) {
   const tokenMap = useTokenMap();
+  const theme = useTheme();
   let tokenInfo = tokenMap.get(mint.toString());
+
   return (
-    <Typography style={{ marginLeft: "10px", marginRight: "5px", ...style }}>
+    <Typography
+      style={{
+        marginLeft: theme.spacing(1.4),
+        marginRight: theme.spacing(1),
+        ...style,
+      }}
+    >
       {tokenInfo?.symbol}
     </Typography>
   );


### PR DESCRIPTION
The current code uses hardcoded CSS dimensions which break responsiveness on mobile. They have been replaced by  `theme.spacing()` for adaptive resizing.

# Screenshots

## Mobile

![image](https://user-images.githubusercontent.com/49580849/121580503-712b8400-ca4a-11eb-9b74-17e9e5b2dd4a.png)

![image](https://user-images.githubusercontent.com/49580849/121580459-68d34900-ca4a-11eb-97a2-c58978e8678a.png)

## Desktop

![image](https://user-images.githubusercontent.com/49580849/121580298-345f8d00-ca4a-11eb-8b1c-4b0233a9b713.png)

![image](https://user-images.githubusercontent.com/49580849/121580563-7e487300-ca4a-11eb-971f-3e2f0c9db6a8.png)

