### PR TITLE
Prepare script to allow module installs from Github

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "lint": "prettier src/** example/src/** --check",
     "lint:fix": "prettier src/** example/src/** -w",
     "build": "rm -rf dist && tsc --build tsconfig.json",
-    "docs": "typedoc --excludePrivate --out ./docs src/index.tsx --includeVersion --readme none"
+    "docs": "typedoc --excludePrivate --out ./docs src/index.tsx --includeVersion --readme none",
+    "prepare": "yarn build"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
NPM allows you to install modules directly from Github, which is useful for testing forks. Syntax:

```sh
npm i https://github.com/project-serum/swap-ui
```

The build files for this repo go in the `dist` folder, which is not committed in version control. This breaks the intended behaviour of the above script. The `dist` folder does not get added to `node_modules`.

This can be remedied with a `prepare` script. These scripts are run on client side when modules are installed from github.

Source: https://stackoverflow.com/a/50490565/7721443