### PR TITLE
Export providers and low level components from NPM module

### DIFF
--- a/src/components/Swap.tsx
+++ b/src/components/Swap.tsx
@@ -116,7 +116,7 @@ export default function SwapCard({
   );
 }
 
-function SwapHeader() {
+export function SwapHeader() {
   return (
     <div
       style={{
@@ -180,7 +180,7 @@ function SwapToForm({ style }: { style?: any }) {
   );
 }
 
-function SwapTokenForm({
+export function SwapTokenForm({
   from,
   style,
   mint,
@@ -301,7 +301,7 @@ function TokenName({ mint, style }: { mint: PublicKey; style: any }) {
   );
 }
 
-function SwapButton() {
+export function SwapButton() {
   const styles = useStyles();
   const {
     fromMint,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,16 +4,31 @@ import { PublicKey } from "@solana/web3.js";
 import { TokenListContainer } from "@solana/spl-token-registry";
 import { Provider } from "@project-serum/anchor";
 import { Swap as SwapClient } from "@project-serum/swap";
-import { SwapContextProvider } from "./context/Swap";
-import { DexContextProvider } from "./context/Dex";
-import { TokenListContextProvider } from "./context/TokenList";
-import { TokenContextProvider } from "./context/Token";
-import SwapCard from "./components/Swap";
 import {
   createMuiTheme,
   ThemeOptions,
   ThemeProvider,
 } from "@material-ui/core/styles";
+import {
+  SwapContextProvider,
+  useSwapContext,
+  useSwapFair,
+} from "./context/Swap";
+import {
+  DexContextProvider,
+  useBbo,
+  useFairRoute,
+  useMarketName,
+} from "./context/Dex";
+import { TokenListContextProvider, useTokenMap } from "./context/TokenList";
+import { TokenContextProvider, useMint } from "./context/Token";
+import SwapCard, {
+  ArrowButton,
+  SwapButton,
+  SwapHeader,
+  SwapTokenForm,
+} from "./components/Swap";
+import TokenDialog from "./components/TokenDialog";
 
 /**
  * A`Swap` component that can be embedded into applications. To use,
@@ -30,7 +45,7 @@ import {
  * For information on other properties like earning referrals, see the
  * [[SwapProps]] documentation.
  */
-export function Swap(props: SwapProps): ReactElement {
+export default function Swap(props: SwapProps): ReactElement {
   const {
     containerStyle,
     contentStyle,
@@ -153,4 +168,29 @@ export type SwapProps = {
   swapTokenContainerStyle?: any;
 };
 
-export default Swap;
+export {
+  // Components
+  Swap,
+  SwapCard,
+  SwapHeader,
+  SwapTokenForm,
+  ArrowButton,
+  SwapButton,
+  TokenDialog,
+  // Providers and context
+  // Swap
+  SwapContextProvider,
+  useSwapContext,
+  useSwapFair,
+  // TokenList
+  TokenListContextProvider,
+  useTokenMap,
+  //  Token
+  TokenContextProvider,
+  useMint,
+  // Dex
+  DexContextProvider,
+  useFairRoute,
+  useMarketName,
+  useBbo,
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -169,7 +169,7 @@ export type SwapProps = {
 };
 
 export {
-  // Components
+  // Components.
   Swap,
   SwapCard,
   SwapHeader,
@@ -177,18 +177,18 @@ export {
   ArrowButton,
   SwapButton,
   TokenDialog,
-  // Providers and context
-  // Swap
+  // Providers and context.
+  // Swap.
   SwapContextProvider,
   useSwapContext,
   useSwapFair,
-  // TokenList
+  // TokenList.
   TokenListContextProvider,
   useTokenMap,
-  //  Token
+  // Token.
   TokenContextProvider,
   useMint,
-  // Dex
+  // Dex.
   DexContextProvider,
   useFairRoute,
   useMarketName,


### PR DESCRIPTION
Resolves #40

Providers and components used by `swap-ui` can be useful outside of the widget. For example for:
1. Customizing the swap widget
2. Getting the list of tokens, finding swap routes etc.

Instead of duplicating code, it will be better if users get access to these lower level components. This is a non-breaking change.