### PR TITLE
fix: Remove global CSS, use commonjs to support Next.js

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,3 +1,4 @@
+import "@fontsource/roboto";
 import { useState, useEffect, useMemo } from "react";
 import { SnackbarProvider, useSnackbar } from "notistack";
 import { Button, Grid, makeStyles } from "@material-ui/core";

--- a/example/src/index.css
+++ b/example/src/index.css
@@ -1,3 +1,4 @@
+@import url("https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;700&display=swap");
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "homepage": "https://github.com/project-serum/swap-ui",
   "license": "Apache-2.0",
   "dependencies": {
-    "@fontsource/roboto": "^4.3.0",
     "@project-serum/serum": "^0.13.34",
     "@project-serum/swap": "^0.1.0-alpha.31",
     "@solana/spl-token": "^0.1.4"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     ]
   },
   "devDependencies": {
+    "@fontsource/roboto": "4.3.0",
     "@material-ui/core": "^4.11.4",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,0 @@
-@import url("https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;700&display=swap");

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,3 @@
-import "@fontsource/roboto";
 import { ReactElement } from "react";
 import { PublicKey } from "@solana/web3.js";
 import { TokenListContainer } from "@solana/spl-token-registry";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
-    "module": "esnext",
+    "module": "commonjs",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1255,11 +1255,6 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fontsource/roboto@^4.3.0":
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/@fontsource/roboto/-/roboto-4.3.0.tgz#00f1cceca43eff85bb0e1d424311751ee41f6aa6"
-  integrity sha512-WeFWCWYutLWyEtRmBhn+bLbW4/km0l+HhTpR8wWDxJLiGiMOhVLO/Z0q5w6l20ZOkWnf6Z1rN3o3W2HjvYN6Rg==
-
 "@hapi/address@2.x.x":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1255,6 +1255,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@fontsource/roboto@4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@fontsource/roboto/-/roboto-4.3.0.tgz#00f1cceca43eff85bb0e1d424311751ee41f6aa6"
+  integrity sha512-WeFWCWYutLWyEtRmBhn+bLbW4/km0l+HhTpR8wWDxJLiGiMOhVLO/Z0q5w6l20ZOkWnf6Z1rN3o3W2HjvYN6Rg==
+
 "@hapi/address@2.x.x":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"


### PR DESCRIPTION
Resolves #46

The README should be updated asking the NPM module users to install Roboto.

For the example itself, there's no noticeable change in the fonts.

![image](https://user-images.githubusercontent.com/49580849/122196543-f2ed3880-ceb4-11eb-8245-1b7000450759.png)
