### PR TITLE
Package manager agnostic prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint:fix": "prettier src/** example/src/** -w",
     "build": "rm -rf dist && tsc --build tsconfig.json",
     "docs": "typedoc --excludePrivate --out ./docs src/index.tsx --includeVersion --readme none",
-    "prepare": "yarn build"
+    "prepare": "tsc --build tsconfig.json"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
Currently the prepare script (#41) breaks if the client doesn't have yarn installed. This is problematic for CI/CD systems, as Yarn will have to be added as a dev dependency or via some other way. For example Netlify is having this issue.

The `yarn build` command invoked by this script itself uses `tsc --build tsconfig.json`. We can call this directly and eliminate the yarn command.
