### PR TITLE
fix: 'Trying to access beyond buffer length' error

### DIFF
--- a/src/context/Token.tsx
+++ b/src/context/Token.tsx
@@ -128,12 +128,18 @@ export function useOwnedTokenAccount(
       listener = provider.connection.onAccountChange(
         tokenAccount.publicKey,
         (info) => {
-          const token = parseTokenAccountData(info.data);
-          if (token.amount !== tokenAccount.account.amount) {
-            const index = _OWNED_TOKEN_ACCOUNTS_CACHE.indexOf(tokenAccount);
-            assert.ok(index >= 0);
-            _OWNED_TOKEN_ACCOUNTS_CACHE[index].account = token;
-            setRefresh((r) => r + 1);
+          if (info.data.length !== 0) {
+            try {
+              const token = parseTokenAccountData(info.data);
+              if (token.amount !== tokenAccount.account.amount) {
+                const index = _OWNED_TOKEN_ACCOUNTS_CACHE.indexOf(tokenAccount);
+                assert.ok(index >= 0);
+                _OWNED_TOKEN_ACCOUNTS_CACHE[index].account = token;
+                setRefresh((r) => r + 1);
+              }
+            } catch (error) {
+              console.log("Failed to decode token AccountInfo");
+            }
           }
         }
       );


### PR DESCRIPTION
Sometimes `connection.onAccountChange()` receives an empty buffer, causing an error

```
←→1 of 2 errors on the page
Unhandled Rejection (RangeError): Trying to access beyond buffer length
▶ 4 stack frames were collapsed.
parseTokenAccountData
src/utils/tokens.ts:73
  70 | 
  71 | export function parseTokenAccountData(data: Buffer): TokenAccount {
  72 |   // @ts-ignore
> 73 |   let { mint, owner, amount } = ACCOUNT_LAYOUT.decode(data);
  74 |   // @ts-ignore
  75 |   return {
  76 |     mint: new PublicKey(mint),
```

Try-catch exception handling is added and decodes are not attempted on empty buffers.